### PR TITLE
docs(README): Remove typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Finally, reference your build output by adding the following fields to your `pac
   "typings": "./[package-name].d.ts",
   "main": "./bundles/[package-name].umd.js",
   "module": "./esm5/[package-name].js",
-  "es2015": "./esm2015/[package-name].js","
+  "es2015": "./esm2015/[package-name].js",
 }
 ```
 


### PR DESCRIPTION
Every time I create a lib project, I have to correct it when I copy/paste this code sample, so I prefer to correct the readme file 😅

BTW, to let you know, we choose to use `angular-package-builder` in our organization (and on our open source project) to build every lib we will create 😎.