### PR TITLE
chore(ci): Speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -233,7 +233,6 @@ jobs:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
-
     -
       env:
         - ANGULAR=4.3.x
@@ -300,7 +299,6 @@ jobs:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
-
     -
       env:
         - ANGULAR=4.4.x
@@ -390,7 +388,6 @@ jobs:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
-
     -
       env:
         - ANGULAR=5.1.x
@@ -502,7 +499,7 @@ jobs:
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-  - stage: test (Angular 6)
+    - stage: test (Angular 6)
       env:
         - ANGULAR=6.0.x
         - TYPESCRIPT=2.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -499,29 +499,6 @@ jobs:
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-    - stage: test (Angular 6)
-      env:
-        - ANGULAR=6.0.x
-        - TYPESCRIPT=2.7.x
-      before_install:
-        - npm install -g npm
-      install:
-        - npm ci
-      before_script:
-        - npm run build
-        - rimraf -r node_modules/**
-        - cd test/my-library
-        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@6.0.x copyfiles --no-save --no-package-lock
-        - npm run build:lib
-        - cd ../my-app
-        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
-        - cd ../..
-        - npm ci
-      script:
-        - npm run test:package
-        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
-        - npm run test:integration
-
     - stage: release
       node_js:
         - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,9 @@ branches:
 # Build stages
 stages:
   - name: build
-  - name: test (Angular 4.0)
-  - name: test (Angular 4.1)
-  - name: test (Angular 4.2)
-  - name: test (Angular 4.3)
-  - name: test (Angular 4.4)
-  - name: test (Angular 5.0)
-  - name: test (Angular 5.1)
-  - name: test (Angular 5.2)
+  - name: test (Angular 4)
+  - name: test (Angular 5)
+  - name: test (Angular 6)
   - name: release
     if: branch = master
 
@@ -33,19 +28,21 @@ jobs:
   include:
 
     - stage: build
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       script:
         - npm run build
 
-    - stage: test (Angular 4.0)
+    - stage: test (Angular 4)
       env:
         - ANGULAR=4.0.x
         - TYPESCRIPT=2.1.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -55,28 +52,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
-      script:
-        - npm run test:package
-        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
-        - npm run test:integration
-    -
-      env:
-        - ANGULAR=4.0.x
-        - TYPESCRIPT=2.2.x
-      install:
-        - npm install -g npm
-        - npm install
-      before_script:
-        - npm run build
-        - rimraf -r node_modules/**
-        - cd test/my-library
-        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@5.5.x copyfiles --no-save --no-package-lock
-        - npm run build:lib
-        - cd ../my-app
-        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
-        - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -84,10 +60,11 @@ jobs:
     -
       env:
         - ANGULAR=4.0.x
-        - TYPESCRIPT=2.3.x
-      install:
+        - TYPESCRIPT=2.2.x
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -97,40 +74,19 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
-      script:
-        - npm run test:package
-        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
-        - npm run test:integration
-
-    - stage: test (Angular 4.1)
-      env:
-        - ANGULAR=4.1.x
-        - TYPESCRIPT=2.1.x
-      install:
-        - npm install -g npm
-        - npm install
-      before_script:
-        - npm run build
-        - rimraf -r node_modules/**
-        - cd test/my-library
-        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@5.5.x copyfiles --no-save --no-package-lock
-        - npm run build:lib
-        - cd ../my-app
-        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
-        - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
     -
       env:
-        - ANGULAR=4.1.x
-        - TYPESCRIPT=2.2.x
-      install:
+        - ANGULAR=4.0.x
+        - TYPESCRIPT=2.3.x
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -140,7 +96,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -148,10 +104,11 @@ jobs:
     -
       env:
         - ANGULAR=4.1.x
-        - TYPESCRIPT=2.3.x
-      install:
+        - TYPESCRIPT=2.1.x
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -161,19 +118,19 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
-
-    - stage: test (Angular 4.2)
+    -
       env:
-        - ANGULAR=4.2.x
-        - TYPESCRIPT=2.1.x
-      install:
+        - ANGULAR=4.1.x
+        - TYPESCRIPT=2.2.x
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -183,7 +140,51 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
+      script:
+        - npm run test:package
+        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
+        - npm run test:integration
+    -
+      env:
+        - ANGULAR=4.1.x
+        - TYPESCRIPT=2.3.x
+      before_install:
+        - npm install -g npm
+      install:
+        - npm ci
+      before_script:
+        - npm run build
+        - rimraf -r node_modules/**
+        - cd test/my-library
+        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@5.5.x copyfiles --no-save --no-package-lock
+        - npm run build:lib
+        - cd ../my-app
+        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
+        - cd ../..
+        - npm ci
+      script:
+        - npm run test:package
+        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
+        - npm run test:integration
+    -
+      env:
+        - ANGULAR=4.2.x
+        - TYPESCRIPT=2.1.x
+      before_install:
+        - npm install -g npm
+      install:
+        - npm ci
+      before_script:
+        - npm run build
+        - rimraf -r node_modules/**
+        - cd test/my-library
+        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@5.5.x copyfiles --no-save --no-package-lock
+        - npm run build:lib
+        - cd ../my-app
+        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
+        - cd ../..
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -192,9 +193,10 @@ jobs:
       env:
         - ANGULAR=4.2.x
         - TYPESCRIPT=2.2.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -204,7 +206,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -213,9 +215,10 @@ jobs:
       env:
         - ANGULAR=4.2.x
         - TYPESCRIPT=2.3.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -225,19 +228,20 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-    - stage: test (Angular 4.3)
+    -
       env:
         - ANGULAR=4.3.x
         - TYPESCRIPT=2.1.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -247,7 +251,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -256,9 +260,10 @@ jobs:
       env:
         - ANGULAR=4.3.x
         - TYPESCRIPT=2.2.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -268,7 +273,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -277,9 +282,10 @@ jobs:
       env:
         - ANGULAR=4.3.x
         - TYPESCRIPT=2.3.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -289,19 +295,20 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-    - stage: test (Angular 4.4)
+    -
       env:
         - ANGULAR=4.4.x
         - TYPESCRIPT=2.1.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -311,7 +318,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -320,9 +327,10 @@ jobs:
       env:
         - ANGULAR=4.4.x
         - TYPESCRIPT=2.2.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -332,7 +340,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -341,9 +349,10 @@ jobs:
       env:
         - ANGULAR=4.4.x
         - TYPESCRIPT=2.3.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -353,19 +362,20 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.4.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-    - stage: test (Angular 5.0)
+    - stage: test (Angular 5)
       env:
         - ANGULAR=5.0.x
         - TYPESCRIPT=2.4.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -375,19 +385,20 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
 
-    - stage: test (Angular 5.1)
+    -
       env:
         - ANGULAR=5.1.x
         - TYPESCRIPT=2.4.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -397,7 +408,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -406,9 +417,10 @@ jobs:
       env:
         - ANGULAR=5.1.x
         - TYPESCRIPT=2.5.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -418,19 +430,19 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
         - npm run test:integration
-
-    - stage: test (Angular 5.2)
+    -
       env:
         - ANGULAR=5.2.x
         - TYPESCRIPT=2.4.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -440,7 +452,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -449,9 +461,10 @@ jobs:
       env:
         - ANGULAR=5.2.x
         - TYPESCRIPT=2.5.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -461,7 +474,7 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -470,9 +483,10 @@ jobs:
       env:
         - ANGULAR=5.2.x
         - TYPESCRIPT=2.6.x
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       before_script:
         - npm run build
         - rimraf -r node_modules/**
@@ -482,7 +496,30 @@ jobs:
         - cd ../my-app
         - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
         - cd ../..
-        - npm install
+        - npm ci
+      script:
+        - npm run test:package
+        - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
+        - npm run test:integration
+
+  - stage: test (Angular 6)
+      env:
+        - ANGULAR=6.0.x
+        - TYPESCRIPT=2.7.x
+      before_install:
+        - npm install -g npm
+      install:
+        - npm ci
+      before_script:
+        - npm run build
+        - rimraf -r node_modules/**
+        - cd test/my-library
+        - npm install $( npm pack ../../dist | tail -1 ) @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR typescript@$TYPESCRIPT rxjs@6.0.x copyfiles --no-save --no-package-lock
+        - npm run build:lib
+        - cd ../my-app
+        - npm install @angular/compiler@$ANGULAR @angular/compiler-cli@$ANGULAR @angular/core@$ANGULAR @angular/common@$ANGULAR @angular/platform-browser@$ANGULAR @angular/platform-browser-dynamic@$ANGULAR typescript@$TYPESCRIPT @angular/cli@1.7.x rxjs@5.5.x zone.js@0.8.x --no-save --no-package-lock
+        - cd ../..
+        - npm ci
       script:
         - npm run test:package
         - cd test/my-app && npm install ../my-library/dist --no-save --no-package-lock && cd ../.. && rimraf -r node_modules/**
@@ -498,9 +535,10 @@ jobs:
         - git checkout -qf "$TRAVIS_COMMIT";
         #  Fix Travis CI issue of detached heads in git
         - git checkout master
-      install:
+      before_install:
         - npm install -g npm
-        - npm install
+      install:
+        - npm ci
       script:
         - npm run build
       before_deploy:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,33 +5,33 @@
 	"requires": true,
 	"dependencies": {
 		"@angular/common": {
-			"version": "5.2.9",
-			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.9.tgz",
-			"integrity": "sha512-g2hPcI0fnT4TV+Fd+1IohjuqBxPvxwyH9IzTn8PkU9X2M+F6cHCUvHxL1sWI2sF8pYcaHzVjq9WClym10X36Lg==",
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.10.tgz",
+			"integrity": "sha512-4zgI/Q6bo/KCvrDPf8gc2IpTJ3PFKgd9RF4jZuh1uc+uEYTAj396tDF8o412AJ/iwtYOHWUx+YgzAvT8dHXZ5Q==",
 			"dev": true,
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/compiler": {
-			"version": "5.2.9",
-			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.9.tgz",
-			"integrity": "sha512-mN+ofInk8y/tk2TCJZx8RrGdOKdrfunoCair7tfDy4XoQJE90waGfaYWo07hYU+UYwLhrg19m2Czy6rIDciUJA==",
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.10.tgz",
+			"integrity": "sha512-FI9ip+aWGpKQB+VfNbFQ+wyh0K4Th8Q/MrHxW6CN4BYVAfFtfORRohvyyYk0sRxuQO8JFN3W/FFfdXjuL+cZKw==",
 			"dev": true,
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@angular/compiler-cli": {
-			"version": "5.2.9",
-			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.9.tgz",
-			"integrity": "sha512-LAEpL/6PAev3zwTow/43Atzv9AtKLAiLoS285X3EV1f80yQpYAmFRrPUtDlrIZdhZHBBv7CxnyCVpOLU3T8ohw==",
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.10.tgz",
+			"integrity": "sha512-RhI26rVALRn3LrU0CAIEj56m60vLyCd8e2Ah79yRP6vlXL8k6SylXytUljTeXIBtiVu2Bi1qKGf2s1X674GzCw==",
 			"dev": true,
 			"requires": {
 				"chokidar": "1.7.0",
 				"minimist": "1.2.0",
 				"reflect-metadata": "0.1.12",
-				"tsickle": "0.27.2"
+				"tsickle": "0.27.5"
 			},
 			"dependencies": {
 				"minimist": {
@@ -43,27 +43,27 @@
 			}
 		},
 		"@angular/core": {
-			"version": "5.2.9",
-			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.9.tgz",
-			"integrity": "sha512-cvHBJGtasrIoARvbLFyHaOsiWKVwMNrrSTZLwrlyHP8oYzkDrE0qKGer6QCqyKt+51hF53cgWEffGzM/u/0wYg==",
+			"version": "5.2.10",
+			"resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.10.tgz",
+			"integrity": "sha512-glDuTtHTcAVhfU3NVewxz/W+Iweq5IaeW2tnMa+RKLopYk9fRs8eR5iTixTGvegwKR770vfXg/gR7P6Ii5cYGQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "1.9.0"
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.42",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz",
-			"integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+			"integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.42"
+				"@babel/highlight": "7.0.0-beta.46"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.42",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.42.tgz",
-			"integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
+			"version": "7.0.0-beta.46",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+			"integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
 			"dev": true,
 			"requires": {
 				"chalk": "2.3.2",
@@ -80,12 +80,39 @@
 				"glob-to-regexp": "0.3.0"
 			}
 		},
+		"@octokit/rest": {
+			"version": "15.2.7",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.2.7.tgz",
+			"integrity": "sha512-uAON7+eNEs1Mfxin3ELgZ6FbJ+VR6o3mRZLrSCUl1dLEbsqnL6CcWI7uRB5cmGwaOMG3dMDneTHnRONcrEDADA==",
+			"dev": true,
+			"requires": {
+				"before-after-hook": "1.1.0",
+				"btoa-lite": "1.0.0",
+				"debug": "3.1.0",
+				"http-proxy-agent": "2.1.0",
+				"https-proxy-agent": "2.2.1",
+				"lodash": "4.17.10",
+				"node-fetch": "2.1.2",
+				"url-template": "2.0.8"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
 		"@types/acorn": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
 			"integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
 			"requires": {
-				"@types/estree": "0.0.38"
+				"@types/estree": "0.0.39"
 			}
 		},
 		"@types/clean-css": {
@@ -95,20 +122,20 @@
 			"dev": true
 		},
 		"@types/estree": {
-			"version": "0.0.38",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
-			"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"@types/jest": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.0.tgz",
-			"integrity": "sha512-5DeGD46Goq6+GtEEB57hQzC/BbuEbEj0fUCDm7a5Fm9ZYLL3odPh1kYn9yMtQe1rKNg/BcVmadroBCyih6thtw==",
+			"version": "22.2.3",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
+			"integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
 			"dev": true
 		},
 		"@types/node": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
-			"integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg==",
+			"version": "9.6.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.12.tgz",
+			"integrity": "sha512-2Z8ziWjJbvV8hHL5YcqCG9ng+/qwUlO1gB4frBD7QI5Wm1Y1iM+AEkGVEv0S5P+aDMwTtAhPJFR4rp1uqagSig==",
 			"dev": true
 		},
 		"@types/node-sass": {
@@ -117,17 +144,7 @@
 			"integrity": "sha1-spbM5xRP+rd7hAkMqtTx5Lvqjgk=",
 			"dev": true,
 			"requires": {
-				"@types/node": "9.6.0"
-			}
-		},
-		"JSONStream": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-			"dev": true,
-			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
+				"@types/node": "9.6.12"
 			}
 		},
 		"abab": {
@@ -202,9 +219,9 @@
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-escapes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 			"dev": true
 		},
 		"ansi-regex": {
@@ -249,7 +266,7 @@
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 			"requires": {
 				"delegates": "1.0.0",
-				"readable-stream": "2.3.5"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"argparse": {
@@ -384,33 +401,25 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-			"integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
 		},
 		"automatic-release": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/automatic-release/-/automatic-release-1.1.0.tgz",
-			"integrity": "sha512-qbacUEek/8y/6i5JQhe7P0gyoUE5qC1L+eVm/52mjIw2M+PkTQyD1H+IOkbWPXQC7bFat5Yiiql5Xsw1/7L19Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/automatic-release/-/automatic-release-1.1.1.tgz",
+			"integrity": "sha512-1v6aujcq4HhCsx3/NmFr2bi9kyFnVON6cxb3KI1D0RtklboLJ2pAugyuszhjKmWYb/IZkUEo+tU42Qc0BusEIg==",
 			"dev": true,
 			"requires": {
+				"@octokit/rest": "15.2.7",
 				"chalk": "2.3.2",
-				"conventional-changelog": "1.1.18",
+				"conventional-changelog": "1.1.24",
 				"conventional-github-releaser": "2.0.2",
-				"conventional-recommended-bump": "1.0.3",
-				"github": "12.0.7",
+				"conventional-recommended-bump": "2.0.9",
 				"github-remove-all-releases": "1.0.1",
 				"parse-github-url": "1.0.2",
-				"semver": "5.4.1",
-				"simple-git": "1.81.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-					"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-					"dev": true
-				}
+				"semver": "5.5.0",
+				"simple-git": "1.92.0"
 			}
 		},
 		"aws-sign2": {
@@ -419,9 +428,9 @@
 			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
 		},
 		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -462,9 +471,9 @@
 			}
 		},
 		"babel-core": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
 				"babel-code-frame": "6.26.0",
@@ -480,7 +489,7 @@
 				"convert-source-map": "1.5.1",
 				"debug": "2.6.9",
 				"json5": "0.5.1",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"minimatch": "3.0.4",
 				"path-is-absolute": "1.0.1",
 				"private": "0.1.8",
@@ -499,7 +508,7 @@
 				"babel-types": "6.26.0",
 				"detect-indent": "4.0.0",
 				"jsesc": "1.3.0",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"source-map": "0.5.7",
 				"trim-right": "1.0.1"
 			}
@@ -520,7 +529,7 @@
 			"integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.5",
+				"babel-plugin-istanbul": "4.1.6",
 				"babel-preset-jest": "22.4.3"
 			}
 		},
@@ -534,11 +543,12 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-			"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
 				"find-up": "2.1.0",
 				"istanbul-lib-instrument": "1.10.1",
 				"test-exclude": "4.2.1"
@@ -568,9 +578,9 @@
 			"dev": true
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"version": "6.26.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
@@ -605,11 +615,11 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
+				"babel-core": "6.26.3",
 				"babel-runtime": "6.26.0",
-				"core-js": "2.5.3",
+				"core-js": "2.5.5",
 				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"mkdirp": "0.5.1",
 				"source-map-support": "0.4.18"
 			},
@@ -630,7 +640,7 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.3",
+				"core-js": "2.5.5",
 				"regenerator-runtime": "0.11.1"
 			}
 		},
@@ -644,7 +654,7 @@
 				"babel-traverse": "6.26.0",
 				"babel-types": "6.26.0",
 				"babylon": "6.18.0",
-				"lodash": "4.17.5"
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-traverse": {
@@ -661,7 +671,7 @@
 				"debug": "2.6.9",
 				"globals": "9.18.0",
 				"invariant": "2.2.4",
-				"lodash": "4.17.5"
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-types": {
@@ -672,7 +682,7 @@
 			"requires": {
 				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"to-fast-properties": "1.0.3"
 			}
 		},
@@ -709,10 +719,41 @@
 						"is-descriptor": "1.0.2"
 					}
 				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -724,6 +765,12 @@
 			"requires": {
 				"tweetnacl": "0.14.5"
 			}
+		},
+		"before-after-hook": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+			"integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
@@ -797,6 +844,12 @@
 			"requires": {
 				"node-int64": "0.4.0"
 			}
+		},
+		"btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.0.0",
@@ -889,7 +942,7 @@
 			"requires": {
 				"ansi-styles": "3.2.1",
 				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.3.0"
+				"supports-color": "5.4.0"
 			}
 		},
 		"chokidar": {
@@ -932,61 +985,10 @@
 						"is-descriptor": "0.1.6"
 					}
 				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					}
-				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -1089,7 +1091,7 @@
 			"requires": {
 				"buffer-from": "1.0.0",
 				"inherits": "2.0.3",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"typedarray": "0.0.6"
 			}
 		},
@@ -1098,29 +1100,23 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
-		"content-type-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-			"dev": true
-		},
 		"conventional-changelog": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.18.tgz",
-			"integrity": "sha512-swf5bqhm7PsY2cw6zxuPy6+rZiiGwEpQnrWki+L+z2oZI53QSYwU4brpljmmWss821AsiwmVL+7V6hP+ER+TBA==",
+			"version": "1.1.24",
+			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+			"integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
 			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "1.6.6",
-				"conventional-changelog-atom": "0.2.4",
-				"conventional-changelog-codemirror": "0.3.4",
-				"conventional-changelog-core": "2.0.5",
-				"conventional-changelog-ember": "0.3.6",
-				"conventional-changelog-eslint": "1.0.5",
-				"conventional-changelog-express": "0.3.4",
+				"conventional-changelog-atom": "0.2.8",
+				"conventional-changelog-codemirror": "0.3.8",
+				"conventional-changelog-core": "2.0.11",
+				"conventional-changelog-ember": "0.3.12",
+				"conventional-changelog-eslint": "1.0.9",
+				"conventional-changelog-express": "0.3.6",
 				"conventional-changelog-jquery": "0.1.0",
 				"conventional-changelog-jscs": "0.1.0",
-				"conventional-changelog-jshint": "0.3.4",
-				"conventional-changelog-preset-loader": "1.1.6"
+				"conventional-changelog-jshint": "0.3.8",
+				"conventional-changelog-preset-loader": "1.1.8"
 			}
 		},
 		"conventional-changelog-angular": {
@@ -1134,37 +1130,37 @@
 			}
 		},
 		"conventional-changelog-atom": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.4.tgz",
-			"integrity": "sha512-4+hmbBwcAwx1XzDZ4aEOxk/ONU0iay10G0u/sld16ksgnRUHN7CxmZollm3FFaptr6VADMq1qxomA+JlpblBlg==",
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
+			"integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
 			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-codemirror": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.4.tgz",
-			"integrity": "sha512-8M7pGgQVzRU//vG3rFlLYqqBywOLxu9XM0/lc1/1Ll7RuKA79PgK9TDpuPmQDHFnqGS7D1YiZpC3Z0D9AIYExg==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
+			"integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
 			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-core": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.5.tgz",
-			"integrity": "sha512-lP1s7Z3NyEFcG78bWy7GG7nXsq9OpAJgo2xbyAlVBDweLSL5ghvyEZlkEamnAQpIUVK0CAVhs8nPvCiQuXT/VA==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
+			"integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-writer": "3.0.4",
-				"conventional-commits-parser": "2.1.5",
+				"conventional-changelog-writer": "3.0.9",
+				"conventional-commits-parser": "2.1.7",
 				"dateformat": "3.0.3",
 				"get-pkg-repo": "1.4.0",
-				"git-raw-commits": "1.3.4",
+				"git-raw-commits": "1.3.6",
 				"git-remote-origin-url": "2.0.0",
-				"git-semver-tags": "1.3.4",
-				"lodash": "4.17.5",
+				"git-semver-tags": "1.3.6",
+				"lodash": "4.17.10",
 				"normalize-package-data": "2.4.0",
 				"q": "1.5.1",
 				"read-pkg": "1.1.0",
@@ -1173,27 +1169,27 @@
 			}
 		},
 		"conventional-changelog-ember": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.6.tgz",
-			"integrity": "sha512-hBM1xb5IrjNtsjXaGryPF/Wn36cwyjkNeqX/CIDbJv/1kRFBHsWoSPYBiNVEpg8xE5fcK4DbPhGTDN2sVoPeiA==",
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
+			"integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
 			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-eslint": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.5.tgz",
-			"integrity": "sha512-7NUv+gMOS8Y49uPFRgF7kuLZqpnrKa2bQMZZsc62NzvaJmjUktnV03PYHuXhTDEHt5guvV9gyEFtUpgHCDkojg==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
+			"integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
 			"dev": true,
 			"requires": {
 				"q": "1.5.1"
 			}
 		},
 		"conventional-changelog-express": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.4.tgz",
-			"integrity": "sha512-M+UUb715TXT6l9vyMf4HYvAepnQn0AYTcPi6KHrFsd80E0HErjQnqStBg8i3+Qm7EV9+RyATQEnIhSzHbdQ7+A==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
+			"integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
 			"dev": true,
 			"requires": {
 				"q": "1.5.1"
@@ -1218,9 +1214,9 @@
 			}
 		},
 		"conventional-changelog-jshint": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.4.tgz",
-			"integrity": "sha512-CdrqwDgL56b176FVxHmhuOvnO1dRDQvrMaHyuIVjcFlOXukATz2wVT17g8jQU3LvybVbyXvJRbdD5pboo7/1KQ==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
+			"integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
 			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
@@ -1228,24 +1224,24 @@
 			}
 		},
 		"conventional-changelog-preset-loader": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.6.tgz",
-			"integrity": "sha512-yWPIP9wwsCKeUSPYApnApWhKIDjWRIX/uHejGS1tYfEsQR/bwpDFET7LYiHT+ujNbrlf6h1s3NlPGheOd4yJRQ==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
+			"integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.4.tgz",
-			"integrity": "sha512-EUf/hWiEj3IOa5Jk8XDzM6oS0WgijlYGkUfLc+mDnLH9RwpZqhYIBwgJHWHzEB4My013wx2FhmUu45P6tQrucw==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+			"integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
 			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
-				"conventional-commits-filter": "1.1.5",
+				"conventional-commits-filter": "1.1.6",
 				"dateformat": "3.0.3",
 				"handlebars": "4.0.11",
 				"json-stringify-safe": "5.0.1",
-				"lodash": "4.17.5",
-				"meow": "4.0.0",
+				"lodash": "4.17.10",
+				"meow": "4.0.1",
 				"semver": "5.5.0",
 				"split": "1.0.1",
 				"through2": "2.0.3"
@@ -1302,9 +1298,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
 						"camelcase-keys": "4.2.0",
@@ -1331,7 +1327,7 @@
 					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"read-pkg": {
@@ -1386,25 +1382,25 @@
 			}
 		},
 		"conventional-commits-filter": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.5.tgz",
-			"integrity": "sha512-mj3+WLj8UZE72zO9jocZjx8+W4Bwnx/KHoIz1vb4F8XUXj0XSjp8Y3MFkpRyIpsRiCBX+DkDjxGKF/nfeu7BGw==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
+			"integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
 			"dev": true,
 			"requires": {
 				"is-subset": "0.1.1",
-				"modify-values": "1.0.0"
+				"modify-values": "1.0.1"
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz",
-			"integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+			"integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
 			"dev": true,
 			"requires": {
 				"is-text-path": "1.0.1",
 				"JSONStream": "1.3.2",
-				"lodash": "4.17.5",
-				"meow": "4.0.0",
+				"lodash": "4.17.10",
+				"meow": "4.0.1",
 				"split2": "2.2.0",
 				"through2": "2.0.3",
 				"trim-off-newlines": "1.0.1"
@@ -1461,9 +1457,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
 						"camelcase-keys": "4.2.0",
@@ -1490,7 +1486,7 @@
 					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"read-pkg": {
@@ -1550,12 +1546,12 @@
 			"integrity": "sha512-31dt3fbsl1nS8oODerFbUu+vY0rp99l3U+WscK4+FD5Gl9VzHuplOz1L5dFpvM3ffchxmOIaPxmrtViQbhGU+w==",
 			"dev": true,
 			"requires": {
-				"conventional-changelog": "1.1.18",
+				"conventional-changelog": "1.1.24",
 				"dateformat": "3.0.3",
 				"gh-got": "6.0.0",
-				"git-semver-tags": "1.3.4",
+				"git-semver-tags": "1.3.6",
 				"lodash.merge": "4.6.1",
-				"meow": "4.0.0",
+				"meow": "4.0.1",
 				"object-assign": "4.1.1",
 				"q": "1.5.1",
 				"semver": "5.5.0",
@@ -1614,9 +1610,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
 						"camelcase-keys": "4.2.0",
@@ -1643,7 +1639,7 @@
 					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"read-pkg": {
@@ -1698,18 +1694,153 @@
 			}
 		},
 		"conventional-recommended-bump": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.3.tgz",
-			"integrity": "sha1-RytpsbjwnFxO1A/iikHmPMBL1zY=",
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-2.0.9.tgz",
+			"integrity": "sha512-YE6/o+648qkX3fTNvfBsvPW3tSnbZ6ec3gF0aBahCPgyoVHU2Mw0nUAZ1h1UN65GazpORngrgRC8QCltNYHPpQ==",
 			"dev": true,
 			"requires": {
 				"concat-stream": "1.6.2",
-				"conventional-commits-filter": "1.1.5",
-				"conventional-commits-parser": "2.1.5",
-				"git-raw-commits": "1.3.4",
-				"git-semver-tags": "1.3.4",
-				"meow": "3.7.0",
-				"object-assign": "4.1.1"
+				"conventional-changelog-preset-loader": "1.1.8",
+				"conventional-commits-filter": "1.1.6",
+				"conventional-commits-parser": "2.1.7",
+				"git-raw-commits": "1.3.6",
+				"git-semver-tags": "1.3.6",
+				"meow": "4.0.1",
+				"q": "1.5.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0",
+						"map-obj": "2.0.0",
+						"quick-lru": "1.1.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
+				"meow": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.4.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.2"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
+					}
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "3.2.0",
+						"strip-indent": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
+				}
 			}
 		},
 		"convert-source-map": {
@@ -1738,9 +1869,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.5.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-			"integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+			"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1759,8 +1890,8 @@
 				"glob2base": "0.0.12",
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
-				"resolve": "1.6.0",
-				"safe-buffer": "5.1.1",
+				"resolve": "1.7.1",
+				"safe-buffer": "5.1.2",
 				"shell-quote": "1.6.1",
 				"subarg": "1.0.0"
 			}
@@ -1828,6 +1959,17 @@
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 				}
+			}
+		},
+		"data-urls": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"dev": true,
+			"requires": {
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1"
 			}
 		},
 		"date-time": {
@@ -1915,10 +2057,41 @@
 				"isobject": "3.0.1"
 			},
 			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -1929,7 +2102,7 @@
 			"requires": {
 				"globby": "6.1.0",
 				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
 				"p-map": "1.2.0",
 				"pify": "3.0.0",
 				"rimraf": "2.6.2"
@@ -2013,12 +2186,6 @@
 			"requires": {
 				"is-obj": "1.0.1"
 			}
-		},
-		"dotenv": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-			"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-			"dev": true
 		},
 		"duplexer": {
 			"version": "0.1.1",
@@ -2263,15 +2430,15 @@
 			"integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0="
 		},
 		"fast-glob": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
-			"integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
+			"integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "2.2.1",
 				"glob-parent": "3.1.0",
 				"is-glob": "4.0.0",
-				"merge2": "1.2.1",
-				"micromatch": "3.1.9"
+				"merge2": "1.2.2",
+				"micromatch": "3.1.10"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -2285,17 +2452,15 @@
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
 						"arr-flatten": "1.1.0",
 						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
 						"extend-shallow": "2.0.1",
 						"fill-range": "4.0.0",
 						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
 						"repeat-element": "1.1.2",
 						"snapdragon": "0.8.2",
 						"snapdragon-node": "2.1.1",
@@ -2303,14 +2468,6 @@
 						"to-regex": "3.0.2"
 					},
 					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -2349,6 +2506,42 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
 								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
 							}
 						},
 						"is-descriptor": {
@@ -2442,39 +2635,29 @@
 					}
 				},
 				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-extglob": {
@@ -2519,13 +2702,13 @@
 					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
-					"version": "3.1.9",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
-						"braces": "2.3.1",
+						"braces": "2.3.2",
 						"define-property": "2.0.2",
 						"extend-shallow": "3.0.2",
 						"extglob": "2.0.4",
@@ -2609,26 +2792,6 @@
 			"requires": {
 				"path-exists": "2.1.0",
 				"pinkie-promise": "2.0.1"
-			}
-		},
-		"follow-redirects": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
-			"integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
-			"dev": true,
-			"requires": {
-				"debug": "3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"for-in": {
@@ -2806,14 +2969,14 @@
 			}
 		},
 		"git-raw-commits": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz",
-			"integrity": "sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+			"integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
 			"dev": true,
 			"requires": {
 				"dargs": "4.1.0",
 				"lodash.template": "4.4.0",
-				"meow": "4.0.0",
+				"meow": "4.0.1",
 				"split2": "2.2.0",
 				"through2": "2.0.3"
 			},
@@ -2869,9 +3032,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
 						"camelcase-keys": "4.2.0",
@@ -2898,7 +3061,7 @@
 					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"read-pkg": {
@@ -2971,12 +3134,12 @@
 			}
 		},
 		"git-semver-tags": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.4.tgz",
-			"integrity": "sha512-Xe2Z74MwXZfAezuaO6e6cA4nsgeCiARPzaBp23gma325c/OXdt//PhrknptIaynNeUp2yWtmikV7k5RIicgGIQ==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+			"integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
 			"dev": true,
 			"requires": {
-				"meow": "4.0.0",
+				"meow": "4.0.1",
 				"semver": "5.5.0"
 			},
 			"dependencies": {
@@ -3031,9 +3194,9 @@
 					"dev": true
 				},
 				"meow": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-					"integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
 						"camelcase-keys": "4.2.0",
@@ -3060,7 +3223,7 @@
 					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.1"
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"read-pkg": {
@@ -3124,17 +3287,12 @@
 			}
 		},
 		"github": {
-			"version": "12.0.7",
-			"resolved": "https://registry.npmjs.org/github/-/github-12.0.7.tgz",
-			"integrity": "sha512-m2lDLc7pA8WRWYGHTwXIZr9SlekWLzer5gVp4os37BkbChb9SW+1XEA77zHfzD6f8szdCYK1cxxu/rF+qBeWyA==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+			"integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
 			"dev": true,
 			"requires": {
-				"dotenv": "4.0.0",
-				"follow-redirects": "1.2.6",
-				"https-proxy-agent": "2.2.0",
-				"lodash": "4.17.5",
-				"mime": "2.2.0",
-				"netrc": "0.1.4"
+				"mime": "1.6.0"
 			}
 		},
 		"github-remove-all-releases": {
@@ -3146,23 +3304,6 @@
 				"github": "0.2.4",
 				"meow": "3.7.0",
 				"q": "1.5.1"
-			},
-			"dependencies": {
-				"github": {
-					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-					"integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
-					"dev": true,
-					"requires": {
-						"mime": "1.6.0"
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-					"dev": true
-				}
 			}
 		},
 		"glob": {
@@ -3221,9 +3362,9 @@
 			"requires": {
 				"array-union": "1.0.2",
 				"dir-glob": "2.0.0",
-				"fast-glob": "2.2.0",
+				"fast-glob": "2.2.1",
 				"glob": "7.1.2",
-				"ignore": "3.3.7",
+				"ignore": "3.3.8",
 				"pify": "3.0.0",
 				"slash": "1.0.0"
 			}
@@ -3235,7 +3376,7 @@
 			"optional": true,
 			"requires": {
 				"glob": "7.1.2",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"minimatch": "3.0.4"
 			}
 		},
@@ -3252,10 +3393,10 @@
 				"is-retry-allowed": "1.1.0",
 				"is-stream": "1.1.0",
 				"isurl": "1.0.0",
-				"lowercase-keys": "1.0.0",
+				"lowercase-keys": "1.0.1",
 				"p-cancelable": "0.3.0",
 				"p-timeout": "1.2.1",
-				"safe-buffer": "5.1.1",
+				"safe-buffer": "5.1.2",
 				"timed-out": "4.0.1",
 				"url-parse-lax": "1.0.0",
 				"url-to-options": "1.0.1"
@@ -3538,18 +3679,38 @@
 			}
 		},
 		"html-minifier": {
-			"version": "3.5.12",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
-			"integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
+			"version": "3.5.15",
+			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
+			"integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
 			"requires": {
 				"camel-case": "3.0.0",
 				"clean-css": "4.1.11",
 				"commander": "2.15.1",
 				"he": "1.1.1",
-				"ncname": "1.0.0",
 				"param-case": "2.1.1",
 				"relateurl": "0.2.7",
-				"uglify-js": "3.3.16"
+				"uglify-js": "3.3.23"
+			}
+		},
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "4.2.0",
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
 			}
 		},
 		"http-signature": {
@@ -3563,9 +3724,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
-			"integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
 			"dev": true,
 			"requires": {
 				"agent-base": "4.2.0",
@@ -3590,9 +3751,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
 		},
 		"import-local": {
 			"version": "1.0.0",
@@ -3664,18 +3825,11 @@
 			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
 		},
 		"is-accessor-descriptor": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "6.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-arrayish": {
@@ -3720,18 +3874,11 @@
 			}
 		},
 		"is-data-descriptor": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "6.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-date-object": {
@@ -3741,19 +3888,19 @@
 			"dev": true
 		},
 		"is-descriptor": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "1.0.0",
-				"is-data-descriptor": "1.0.0",
-				"kind-of": "6.0.2"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -3872,9 +4019,9 @@
 			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
 				"is-path-inside": "1.0.1"
 			}
@@ -3929,6 +4076,13 @@
 			"integrity": "sha512-h37O/IX4efe56o9k41II1ECMqKwtqHa7/12dLDEzJIFux2x15an4WCDb0/eKdmUgRpLJ3bR0DrzDc7vOrVgRDw==",
 			"requires": {
 				"@types/estree": "0.0.38"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "0.0.38",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
+					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+				}
 			}
 		},
 		"is-regex": {
@@ -4036,7 +4190,7 @@
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 					"dev": true,
 					"requires": {
-						"lodash": "4.17.5"
+						"lodash": "4.17.10"
 					}
 				},
 				"debug": {
@@ -4188,9 +4342,9 @@
 					"dev": true
 				},
 				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "2.1.1",
@@ -4219,7 +4373,7 @@
 					"integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.0.0",
+						"ansi-escapes": "3.1.0",
 						"chalk": "2.3.2",
 						"exit": "0.1.2",
 						"glob": "7.1.2",
@@ -4297,7 +4451,7 @@
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
+						"cliui": "4.1.0",
 						"decamelize": "1.2.0",
 						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
@@ -4379,7 +4533,7 @@
 			"requires": {
 				"jest-mock": "22.4.3",
 				"jest-util": "22.4.3",
-				"jsdom": "11.6.2"
+				"jsdom": "11.10.0"
 			}
 		},
 		"jest-environment-node": {
@@ -4410,7 +4564,7 @@
 				"jest-serializer": "22.4.3",
 				"jest-worker": "22.4.3",
 				"micromatch": "2.3.11",
-				"sane": "2.5.0"
+				"sane": "2.5.1"
 			}
 		},
 		"jest-jasmine2": {
@@ -4429,7 +4583,7 @@
 				"jest-message-util": "22.4.3",
 				"jest-snapshot": "22.4.3",
 				"jest-util": "22.4.3",
-				"source-map-support": "0.5.4"
+				"source-map-support": "0.5.5"
 			}
 		},
 		"jest-leak-detector": {
@@ -4458,7 +4612,7 @@
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.42",
+				"@babel/code-frame": "7.0.0-beta.46",
 				"chalk": "2.3.2",
 				"micromatch": "2.3.11",
 				"slash": "1.0.0",
@@ -4521,9 +4675,9 @@
 			"integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
+				"babel-core": "6.26.3",
 				"babel-jest": "22.4.3",
-				"babel-plugin-istanbul": "4.1.5",
+				"babel-plugin-istanbul": "4.1.6",
 				"chalk": "2.3.2",
 				"convert-source-map": "1.5.1",
 				"exit": "0.1.2",
@@ -4556,9 +4710,9 @@
 					"dev": true
 				},
 				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "2.1.1",
@@ -4629,7 +4783,7 @@
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"dev": true,
 					"requires": {
-						"cliui": "4.0.0",
+						"cliui": "4.1.0",
 						"decamelize": "1.2.0",
 						"find-up": "2.1.0",
 						"get-caller-file": "1.0.2",
@@ -4748,23 +4902,22 @@
 			"optional": true
 		},
 		"jsdom": {
-			"version": "11.6.2",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
-			"integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.10.0.tgz",
+			"integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
 			"dev": true,
 			"requires": {
 				"abab": "1.0.4",
 				"acorn": "5.5.3",
 				"acorn-globals": "4.1.0",
 				"array-equal": "1.0.0",
-				"browser-process-hrtime": "0.1.2",
-				"content-type-parser": "1.0.2",
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
+				"data-urls": "1.0.0",
 				"domexception": "1.0.1",
 				"escodegen": "1.9.1",
 				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.2.0",
+				"left-pad": "1.3.0",
 				"nwmatcher": "1.4.4",
 				"parse5": "4.0.0",
 				"pn": "1.1.0",
@@ -4776,7 +4929,8 @@
 				"w3c-hr-time": "1.0.1",
 				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "6.4.0",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1",
 				"ws": "4.1.0",
 				"xml-name-validator": "3.0.0"
 			},
@@ -4879,9 +5033,9 @@
 					}
 				},
 				"qs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-					"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
 				},
 				"request": {
@@ -4891,7 +5045,7 @@
 					"dev": true,
 					"requires": {
 						"aws-sign2": "0.7.0",
-						"aws4": "1.6.0",
+						"aws4": "1.7.0",
 						"caseless": "0.12.0",
 						"combined-stream": "1.0.6",
 						"extend": "3.0.1",
@@ -4906,8 +5060,8 @@
 						"mime-types": "2.1.18",
 						"oauth-sign": "0.8.2",
 						"performance-now": "2.1.0",
-						"qs": "6.5.1",
-						"safe-buffer": "5.1.1",
+						"qs": "6.5.2",
+						"safe-buffer": "5.1.2",
 						"stringstream": "0.0.5",
 						"tough-cookie": "2.3.4",
 						"tunnel-agent": "0.6.0",
@@ -4929,7 +5083,7 @@
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -4941,9 +5095,9 @@
 			"dev": true
 		},
 		"json-parse-better-errors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
 		"json-schema": {
@@ -5002,9 +5156,19 @@
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
 		},
 		"jsonschema": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-			"integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+		},
+		"JSONStream": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+			"dev": true,
+			"requires": {
+				"jsonparse": "1.3.1",
+				"through": "2.3.8"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -5048,9 +5212,9 @@
 			}
 		},
 		"left-pad": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-			"integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
 			"dev": true
 		},
 		"leven": {
@@ -5110,9 +5274,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.5",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -5199,9 +5363,9 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
 		},
 		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 			"dev": true
 		},
 		"lru-cache": {
@@ -5306,13 +5470,13 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.5"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"merge2": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-			"integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
 		},
 		"micromatch": {
 			"version": "2.3.11",
@@ -5335,9 +5499,9 @@
 			}
 		},
 		"mime": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-			"integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -5415,9 +5579,9 @@
 			}
 		},
 		"modify-values": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-			"integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
 			"dev": true
 		},
 		"module-not-found-error": {
@@ -5478,20 +5642,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"ncname": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
-			"integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-			"requires": {
-				"xml-char-classes": "1.0.0"
-			}
-		},
-		"netrc": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-			"integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=",
-			"dev": true
-		},
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -5499,6 +5649,12 @@
 			"requires": {
 				"lower-case": "1.1.4"
 			}
+		},
+		"node-fetch": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+			"integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+			"dev": true
 		},
 		"node-gyp": {
 			"version": "3.6.2",
@@ -5548,9 +5704,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
+			"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
 			"optional": true,
 			"requires": {
 				"async-foreach": "0.1.3",
@@ -5721,39 +5877,6 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "0.1.6"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
 					}
 				}
 			}
@@ -6263,16 +6386,16 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
 				"isarray": "1.0.0",
 				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
 				"util-deprecate": "1.0.2"
 			}
 		},
@@ -6283,7 +6406,7 @@
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"minimatch": "3.0.4",
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"set-immediate-shim": "1.0.1"
 			}
 		},
@@ -6367,7 +6490,7 @@
 			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 			"requires": {
 				"aws-sign2": "0.6.0",
-				"aws4": "1.6.0",
+				"aws4": "1.7.0",
 				"caseless": "0.11.0",
 				"combined-stream": "1.0.6",
 				"extend": "3.0.1",
@@ -6394,7 +6517,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.5"
+				"lodash": "4.17.10"
 			}
 		},
 		"request-promise-native": {
@@ -6424,9 +6547,9 @@
 			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
 		},
 		"resolve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
-			"integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"requires": {
 				"path-parse": "1.0.5"
 			}
@@ -6493,20 +6616,20 @@
 			}
 		},
 		"rollup-plugin-commonjs": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.0.tgz",
-			"integrity": "sha512-NrfE0g30QljNCnlJr7I2Xguz+44mh0dCxvfxwLnCwtaCK2LwFUp1zzAs8MQuOfhH4mRskqsjfOwGUap/L+WtEw==",
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz",
+			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
 			"requires": {
-				"estree-walker": "0.5.1",
+				"estree-walker": "0.5.2",
 				"magic-string": "0.22.5",
-				"resolve": "1.6.0",
+				"resolve": "1.7.1",
 				"rollup-pluginutils": "2.0.1"
 			},
 			"dependencies": {
 				"estree-walker": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
-					"integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg=="
+					"version": "0.5.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+					"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
 				}
 			}
 		},
@@ -6517,7 +6640,7 @@
 			"requires": {
 				"builtin-modules": "2.0.0",
 				"is-module": "1.0.0",
-				"resolve": "1.6.0"
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"builtin-modules": {
@@ -6537,18 +6660,18 @@
 			}
 		},
 		"rxjs": {
-			"version": "5.5.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.7.tgz",
-			"integrity": "sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==",
+			"version": "5.5.10",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+			"integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
 			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.1"
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -6559,15 +6682,15 @@
 			}
 		},
 		"sane": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
-			"integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.1.tgz",
+			"integrity": "sha1-pVzucHS+0yE7VLQIie55H6L1AXY=",
 			"dev": true,
 			"requires": {
 				"anymatch": "2.0.0",
 				"exec-sh": "0.2.1",
 				"fb-watchman": "2.0.0",
-				"micromatch": "3.1.9",
+				"micromatch": "3.1.10",
 				"minimist": "1.2.0",
 				"walker": "1.0.7",
 				"watch": "0.18.0"
@@ -6579,7 +6702,7 @@
 					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 					"dev": true,
 					"requires": {
-						"micromatch": "3.1.9",
+						"micromatch": "3.1.10",
 						"normalize-path": "2.1.1"
 					}
 				},
@@ -6596,18 +6719,16 @@
 					"dev": true
 				},
 				"braces": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0",
 						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
 						"extend-shallow": "2.0.1",
 						"fill-range": "4.0.0",
 						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
 						"repeat-element": "1.1.2",
 						"snapdragon": "0.8.2",
 						"snapdragon-node": "2.1.1",
@@ -6615,15 +6736,6 @@
 						"to-regex": "3.0.2"
 					},
 					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -6666,6 +6778,46 @@
 							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
 							}
 						},
 						"is-descriptor": {
@@ -6747,43 +6899,32 @@
 					}
 				},
 				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -6819,14 +6960,14 @@
 					"dev": true
 				},
 				"micromatch": {
-					"version": "3.1.9",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
-						"braces": "2.3.1",
+						"braces": "2.3.2",
 						"define-property": "2.0.2",
 						"extend-shallow": "3.0.2",
 						"extglob": "2.0.4",
@@ -6854,7 +6995,7 @@
 			"optional": true,
 			"requires": {
 				"glob": "7.1.2",
-				"lodash": "4.17.5",
+				"lodash": "4.17.10",
 				"scss-tokenizer": "0.2.3",
 				"yargs": "7.1.0"
 			},
@@ -6993,9 +7134,9 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-git": {
-			"version": "1.81.1",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.81.1.tgz",
-			"integrity": "sha1-RG6tpG6fu8cPROwTIhF1IxJbRQg=",
+			"version": "1.92.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.92.0.tgz",
+			"integrity": "sha1-YGFGjrfRnwFBB4/HQuYkV+kQ9Uc=",
 			"dev": true,
 			"requires": {
 				"debug": "3.1.0"
@@ -7047,57 +7188,6 @@
 					"requires": {
 						"is-extendable": "0.1.1"
 					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					}
-				},
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -7119,10 +7209,41 @@
 						"is-descriptor": "1.0.2"
 					}
 				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					}
+				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -7152,7 +7273,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"requires": {
-				"atob": "2.0.3",
+				"atob": "2.1.1",
 				"decode-uri-component": "0.2.0",
 				"resolve-url": "0.2.1",
 				"source-map-url": "0.4.0",
@@ -7160,11 +7281,12 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
-			"integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
+			"integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
 			"dev": true,
 			"requires": {
+				"buffer-from": "1.0.0",
 				"source-map": "0.6.1"
 			},
 			"dependencies": {
@@ -7290,57 +7412,6 @@
 					"requires": {
 						"is-descriptor": "0.1.6"
 					}
-				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"requires": {
-						"is-accessor-descriptor": "0.1.6",
-						"is-data-descriptor": "0.1.4",
-						"kind-of": "5.1.0"
-					}
-				},
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -7350,7 +7421,7 @@
 			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
 			"optional": true,
 			"requires": {
-				"readable-stream": "2.3.5"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"stealthy-require": {
@@ -7358,6 +7429,14 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
 		},
 		"string-length": {
 			"version": "2.0.0",
@@ -7394,14 +7473,6 @@
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
 				"strip-ansi": "3.0.1"
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {
@@ -7454,9 +7525,9 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"requires": {
 				"has-flag": "3.0.0"
 			}
@@ -7491,7 +7562,7 @@
 			"dev": true,
 			"requires": {
 				"arrify": "1.0.1",
-				"micromatch": "3.1.9",
+				"micromatch": "3.1.10",
 				"object-assign": "4.1.1",
 				"read-pkg-up": "1.0.1",
 				"require-main-filename": "1.0.1"
@@ -7510,18 +7581,16 @@
 					"dev": true
 				},
 				"braces": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-					"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
 						"arr-flatten": "1.1.0",
 						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
 						"extend-shallow": "2.0.1",
 						"fill-range": "4.0.0",
 						"isobject": "3.0.1",
-						"kind-of": "6.0.2",
 						"repeat-element": "1.1.2",
 						"snapdragon": "0.8.2",
 						"snapdragon-node": "2.1.1",
@@ -7529,15 +7598,6 @@
 						"to-regex": "3.0.2"
 					},
 					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"dev": true,
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
 						"extend-shallow": {
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -7580,6 +7640,46 @@
 							"dev": true,
 							"requires": {
 								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
 							}
 						},
 						"is-descriptor": {
@@ -7661,43 +7761,32 @@
 					}
 				},
 				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
+						"kind-of": "6.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -7733,14 +7822,14 @@
 					"dev": true
 				},
 				"micromatch": {
-					"version": "3.1.9",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-					"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
 						"arr-diff": "4.0.0",
 						"array-unique": "0.3.2",
-						"braces": "2.3.1",
+						"braces": "2.3.2",
 						"define-property": "2.0.2",
 						"extend-shallow": "3.0.2",
 						"extglob": "2.0.4",
@@ -7779,7 +7868,7 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.5",
+				"readable-stream": "2.3.6",
 				"xtend": "4.0.1"
 			}
 		},
@@ -7911,14 +8000,14 @@
 			}
 		},
 		"ts-jest": {
-			"version": "22.4.2",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.2.tgz",
-			"integrity": "sha512-H2YEVxwk0Thp7n3RGUMPIEUTwnnE1m48rcYUBvI3DEoDTBf9Puz2w4oKg1y+rPJUdX2ti6/3ku0owOhJc8gBTg==",
+			"version": "22.4.4",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.4.tgz",
+			"integrity": "sha512-v9pO7u4HNMDSBCN9IEvlR6taDAGm2mo7nHEDLWyoFDgYeZ4aHm8JHEPrthd8Pmcl4eCM8J4Ata4ROR/cwFRV2A==",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-plugin-istanbul": "4.1.5",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-core": "6.26.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
 				"babel-preset-jest": "22.4.3",
 				"cpx": "1.5.0",
 				"fs-extra": "4.0.3",
@@ -7941,15 +8030,15 @@
 			}
 		},
 		"tsickle": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.27.2.tgz",
-			"integrity": "sha512-KW+ZgY0t2cq2Qib1sfdgMiRnk+cr3brUtzZoVWjv+Ot3jNxVorFBUH+6In6hl8Dg7BI2AAFf69NHkwvZNMSFwA==",
+			"version": "0.27.5",
+			"resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.27.5.tgz",
+			"integrity": "sha512-NP+CjM1EXza/M8mOXBLH3vkFEJiu1zfEAlC5WdJxHPn8l96QPz5eooP6uAgYtw1CcKfuSyIiheNUdKxtDWCNeg==",
 			"dev": true,
 			"requires": {
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
 				"source-map": "0.6.1",
-				"source-map-support": "0.5.4"
+				"source-map-support": "0.5.5"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7999,15 +8088,15 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-			"integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+			"integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
-			"integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+			"version": "3.3.23",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.23.tgz",
+			"integrity": "sha512-Ks+KqLGDsYn4z+pU7JsKCzC0T3mPYl+rU+VcPZiQOazjE4Uqi4UCRY3qPMDbJi7ze37n1lDXj3biz1ik93vqvw==",
 			"requires": {
 				"commander": "2.15.1",
 				"source-map": "0.6.1"
@@ -8132,6 +8221,12 @@
 				"prepend-http": "1.0.4"
 			}
 		},
+		"url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+			"dev": true
+		},
 		"url-to-options": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
@@ -8255,10 +8350,16 @@
 				"iconv-lite": "0.4.19"
 			}
 		},
+		"whatwg-mimetype": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+			"dev": true
+		},
 		"whatwg-url": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-			"integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
 			"dev": true,
 			"requires": {
 				"lodash.sortby": "4.7.0",
@@ -8333,13 +8434,8 @@
 			"dev": true,
 			"requires": {
 				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "5.1.2"
 			}
-		},
-		"xml-char-classes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
-			"integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -8367,7 +8463,7 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
 			"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 			"requires": {
-				"cliui": "4.0.0",
+				"cliui": "4.1.0",
 				"decamelize": "1.2.0",
 				"find-up": "2.1.0",
 				"get-caller-file": "1.0.2",
@@ -8392,9 +8488,9 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"cliui": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-					"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"requires": {
 						"string-width": "2.1.1",
 						"strip-ansi": "4.0.0",

--- a/test/spec/esm2015.spec.ts
+++ b/test/spec/esm2015.spec.ts
@@ -43,23 +43,11 @@ describe( 'ESM2015 Modules (with Source Maps)', () => {
 
 	} );
 
-	it( 'should all contain classes with attached metadata', () => {
+	it( 'should all contain classes', () => {
 
-		// Module
 		expect( moduleFileContents[ 2 ][ 'LIBModule' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 2 ][ 'LIBModule' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 2 ][ 'LIBModule' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Service
 		expect( moduleFileContents[ 3 ][ 'LIBDataService' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 3 ][ 'LIBDataService' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 3 ][ 'LIBDataService' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Component
 		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].propDecorators ).toEqual( expect.any( Object ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].ctorParameters ).toEqual( expect.any( Function ) );
 
 	} );
 

--- a/test/spec/esm5.spec.ts
+++ b/test/spec/esm5.spec.ts
@@ -43,23 +43,11 @@ describe( 'ESM5 Modules (with Source Maps)', () => {
 
 	} );
 
-	it( 'should all contain classes with attached metadata', () => {
+	it( 'should all contain classes', () => {
 
-		// Module
 		expect( moduleFileContents[ 2 ][ 'LIBModule' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 2 ][ 'LIBModule' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 2 ][ 'LIBModule' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Service
 		expect( moduleFileContents[ 3 ][ 'LIBDataService' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 3 ][ 'LIBDataService' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 3 ][ 'LIBDataService' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Component
 		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].propDecorators ).toEqual( expect.any( Object ) );
-		expect( moduleFileContents[ 4 ][ 'LIBInputComponent' ].ctorParameters ).toEqual( expect.any( Function ) );
 
 	} );
 

--- a/test/spec/fesm2015.spec.ts
+++ b/test/spec/fesm2015.spec.ts
@@ -26,23 +26,11 @@ describe( 'Flat ESM2015 Module (with Source Maps)', () => {
 
 	} );
 
-	it( 'should contain classes with attached metadata', () => {
+	it( 'should all contain classes', () => {
 
-		// Module
 		expect( moduleFileContent[ 'LIBModule' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBModule' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBModule' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Service
 		expect( moduleFileContent[ 'LIBDataService' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBDataService' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBDataService' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Component
 		expect( moduleFileContent[ 'LIBInputComponent' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].propDecorators ).toEqual( expect.any( Object ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].ctorParameters ).toEqual( expect.any( Function ) );
 
 	} );
 

--- a/test/spec/fesm5.spec.ts
+++ b/test/spec/fesm5.spec.ts
@@ -26,23 +26,11 @@ describe( 'Flat ESM5 Module (with Source Maps)', () => {
 
 	} );
 
-	it( 'should contain classes with attached metadata', () => {
+	it( 'should all contain classes', () => {
 
-		// Module
 		expect( moduleFileContent[ 'LIBModule' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBModule' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBModule' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Service
 		expect( moduleFileContent[ 'LIBDataService' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBDataService' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBDataService' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Component
 		expect( moduleFileContent[ 'LIBInputComponent' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].propDecorators ).toEqual( expect.any( Object ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].ctorParameters ).toEqual( expect.any( Function ) );
 
 	} );
 

--- a/test/spec/umd.spec.ts
+++ b/test/spec/umd.spec.ts
@@ -26,23 +26,11 @@ describe( 'UMD Module (with Source Maps)', () => {
 
 	} );
 
-	it( 'should contain classes with attached metadata', () => {
+	it( 'should all contain classes', () => {
 
-		// Module
 		expect( moduleFileContent[ 'LIBModule' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBModule' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBModule' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Service
 		expect( moduleFileContent[ 'LIBDataService' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBDataService' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBDataService' ].ctorParameters ).toEqual( expect.any( Function ) );
-
-		// Component
 		expect( moduleFileContent[ 'LIBInputComponent' ] ).toEqual( expect.any( Function ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].decorators ).toEqual( expect.any( Array ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].propDecorators ).toEqual( expect.any( Object ) );
-		expect( moduleFileContent[ 'LIBInputComponent' ].ctorParameters ).toEqual( expect.any( Function ) );
 
 	} );
 


### PR DESCRIPTION
- Use `npm ci` instead of `npm install`, for CI performance improvements
- Combine Angular tests based in major instead of minor version, for performance improvements due to parallel test execution